### PR TITLE
Added option to set separator of documents

### DIFF
--- a/WikiExtractor.py
+++ b/WikiExtractor.py
@@ -622,7 +622,8 @@ def main():
     script_name = os.path.basename(sys.argv[0])
 
     try:
-        long_opts = ['help', 'compress', 'bytes=', 'basename=', 'links', 'ns=', 'sections', 'output=', 'version']
+        long_opts = ['help', 'compress', 'bytes=', 'basename=', 'links', 'ns=',
+                'sections', 'output=', 'version', 'docseparator=']
         opts, args = getopt.gnu_getopt(sys.argv[1:], 'cb:hln:o:B:sv', long_opts)
     except getopt.GetoptError:
         show_usage(script_name)
@@ -631,6 +632,8 @@ def main():
     compress = False
     file_size = 500 * 1024
     output_dir = '.'
+
+    docseparator = None
 
     for opt, arg in opts:
         if opt in ('-h', '--help'):
@@ -664,6 +667,8 @@ def main():
         elif opt in ('-v', '--version'):
                 print 'WikiExtractor.py version:', version
                 sys.exit(0)
+        elif opt == '--docseparator':
+                docseparator = arg
 
     if len(args) > 0:
         show_usage(script_name)

--- a/WikiExtractor.py
+++ b/WikiExtractor.py
@@ -116,14 +116,20 @@ version = '2.5'
 
 ##### Main function ###########################################################
 
-def WikiDocument(out, id, title, text):
+def WikiDocument(out, id, title, text, docseparator=None):
     url = get_url(id, prefix)
-    header = '<doc id="%s" url="%s" title="%s">\n' % (id, url, title)
+    header = ''
+    if docseparator is None:
+        header = '<doc id="%s" url="%s" title="%s">\n' % (id, url, title)
+
     # Separate header from text with a newline.
     header += title + '\n'
     header = header.encode('utf-8')
     text = clean(text)
-    footer = "\n</doc>"
+    footer = docseparator
+    if docseparator is None:
+        footer = "\n</doc>"
+
     out.reserve(len(header) + len(text) + len(footer))
     print >> out, header
     for line in compact(text):
@@ -555,7 +561,7 @@ class OutputSplitter:
 
 tagRE = re.compile(r'(.*?)<(/?\w+)[^>]*>(?:([^<]*)(<.*?>)?)?')
 
-def process_data(input, output):
+def process_data(input, output, docseparator=None):
     global prefix
 
     page = []
@@ -596,7 +602,7 @@ def process_data(input, output):
                     not redirect:
                 print id, title.encode('utf-8')
                 sys.stdout.flush()
-                WikiDocument(output, id, title, ''.join(page))
+                WikiDocument(output, id, title, ''.join(page), docseparator)
             id = None
             page = []
         elif tag == 'base':
@@ -685,7 +691,7 @@ def main():
         ignoreTag('a')
 
     output_splitter = OutputSplitter(compress, file_size, output_dir)
-    process_data(sys.stdin, output_splitter)
+    process_data(sys.stdin, output_splitter, docseparator)
     output_splitter.close()
 
 if __name__ == '__main__':

--- a/WikiExtractor.py
+++ b/WikiExtractor.py
@@ -51,6 +51,7 @@ Options:
   -o, --output= dir     : place output files in specified directory (default
                           current)
   -s, --sections	: preserve sections
+  -d, --docseparator    : separate pages with given string
   -h, --help            : display this help and exit
 """
 
@@ -630,7 +631,7 @@ def main():
     try:
         long_opts = ['help', 'compress', 'bytes=', 'basename=', 'links', 'ns=',
                 'sections', 'output=', 'version', 'docseparator=']
-        opts, args = getopt.gnu_getopt(sys.argv[1:], 'cb:hln:o:B:sv', long_opts)
+        opts, args = getopt.gnu_getopt(sys.argv[1:], 'cb:hln:o:B:svd:', long_opts)
     except getopt.GetoptError:
         show_usage(script_name)
         sys.exit(1)
@@ -673,7 +674,7 @@ def main():
         elif opt in ('-v', '--version'):
                 print 'WikiExtractor.py version:', version
                 sys.exit(0)
-        elif opt == '--docseparator':
+        elif opt in ('-d', '--docseparator'):
                 docseparator = arg
 
     if len(args) > 0:


### PR DESCRIPTION
Although I'm not sure if this is the right place to send this pull request I found it difficult to work with `<doc>`s.

This pull request implements a `--docseparator` option which allows you to set a different separator of documents.
