### PR TITLE
Use `-` to allow stdin in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,7 @@ The following commands illustrate how to apply the script to a Wikipedia
 dump:
 
     > wget http://download.wikimedia.org/itwiki/latest/itwiki-latest-pages-articles.xml.bz2
-    > bzcat itwiki-latest-pages-articles.xml.bz2 |
-      WikiExtractor.py -cb 250K -o extracted
+    > bzcat itwiki-latest-pages-articles.xml.bz2 | WikiExtractor.py -cb 250K -o extracted -
 
 In order to combine the whole extracted text into a single file one can
 issue:


### PR DESCRIPTION
Cheers bwbaugh! I know this is a mirror, so I didn't touch the script itself, but since you seem to be maintaining a separate `README.md`, I made a small fix to make the `bzcat` usage example to allow input from `stdin`. Kudos on the disk-saving example; this (along with a chmod) should allow folks to use it out of the box.
